### PR TITLE
Restore Abdulazeem Shaikh credit in tagged logistics map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# Live-Logistics-map
+# Live Logistics Map
+
+A simple Leaflet-based map that allows drawing routes and tagging them. The page also shows logistics, supply chain, and port news headlines from up to fifteen reliable RSS sources, refreshing every six hours.
+
+## Usage
+
+Open `index.html` in a web browser. Use the polyline tool to draw routes. When a route is created, you'll be prompted to enter tags. Tags are stored with the line and shown in a popup.
+
+Headlines from sources like The Loadstar, Port Technology, Supply Chain Digital, Maritime Executive, FreightWaves, and other logistics outlets appear in the top-right panel and update automatically. Headlines are analyzed with an AI location extractor that scans for multiple place names, geocodes each, and selects the best match to plot accurate coordinates on the map. Click a headline to focus the map on its marker. Use the filter box in the top-left to limit markers by country and by recency (last day, month, or year) and to show only routes whose tags match a text filter. A theme selector lets you switch between light, dark, satellite, or heatmap views.
+
+Hover over the animated logo in the top-left corner to play its breaking-news animation.
+
+## Building a Windows executable
+
+An Electron wrapper lets the map run as a Windows `.exe` that can fetch online tiles and RSS feeds.
+
+1. Install dependencies (requires internet access):
+
+   ```bash
+   npm install
+   ```
+
+2. Create the installer:
+
+  ```bash
+   npm run build
+   ```
+
+   The generated files appear in the `dist/` folder. Use `npm start` for development.
+
+### Alternative packaging with Nativefier
+
+If installing Electron dependencies is not possible, you can wrap the web app into a Windows executable using [Nativefier](https://github.com/nativefier/nativefier).
+
+1. Install Nativefier:
+
+   ```bash
+   npm install -g nativefier
+   ```
+
+2. Generate the `.exe` directly from `index.html`:
+
+   ```bash
+   nativefier --name "Live Logistics Map" --platform windows index.html
+   ```
+
+   The resulting folder will contain a portable executable that opens the map with full internet access.
+
+## Credits
+Abdulazeem Shaikh

--- a/index.html
+++ b/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<!-- Credits: Abdulazeem Shaikh -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Live Logistics Map</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+oUXSviwHd0x3if52QT11YGpfsVWH3QzUFb7FXq24=" crossorigin=""/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
+  <style>
+    body, html { margin:0; padding:0; height:100%; }
+    body { position: relative; }
+    #map { height:100%; }
+    #news {
+      position:absolute;
+      top:10px;
+      right:10px;
+      background:white;
+      padding:8px;
+      max-width:300px;
+      max-height:200px;
+      overflow-y:auto;
+      z-index:1000;
+      border-radius:4px;
+      box-shadow:0 2px 6px rgba(0,0,0,0.3);
+    }
+    #news h3 { margin-top:0; font-size:16px; }
+    #news ul { list-style:none; padding-left:0; }
+    #news li { margin-bottom:6px; font-size:14px; cursor:pointer; }
+    #news a { text-decoration:none; }
+    .tag-input {
+      display:flex;
+      flex-direction:column;
+    }
+    .tag-input label {
+      margin-bottom:4px;
+    }
+    #logo {
+      position:absolute;
+      top:10px;
+      left:10px;
+      z-index:1001;
+      cursor:pointer;
+    }
+    #logo video {
+      width:120px;
+      height:auto;
+      display:block;
+    }
+    #filters {
+      position:absolute;
+      top:90px;
+      left:10px;
+      background:white;
+      padding:8px;
+      z-index:1000;
+      border-radius:4px;
+      box-shadow:0 2px 6px rgba(0,0,0,0.3);
+      display:flex;
+      flex-direction:column;
+      gap:4px;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <div id="news"><h3>Logistics News</h3><ul id="news-list"></ul></div>
+  <div id="logo">
+    <video id="logo-video" muted loop preload="metadata" src="https://pbs.twimg.com/animated_gif/1875079018449436672/vid/640x360/Dux4spIBvQrM17Yq.mp4"></video>
+  </div>
+  <div id="filters">
+    <select id="country-filter"></select>
+    <select id="time-filter">
+      <option value="day">Last Day</option>
+      <option value="month" selected>Last Month</option>
+      <option value="year">Last Year</option>
+    </select>
+    <select id="theme-select">
+      <option value="light" selected>Light</option>
+      <option value="dark">Dark</option>
+      <option value="satellite">Satellite</option>
+      <option value="heatmap">Heatmap</option>
+    </select>
+    <input id="route-tag-filter" type="text" placeholder="Route tag" />
+    <button id="apply-filters">Apply Filters</button>
+  </div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kGStNqd7KPv1yg8Bz9shAzG+VQJ5xcp1gnusM=" crossorigin=""></script>
+  <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
+  <script src="https://unpkg.com/leaflet.heat/dist/leaflet-heat.js"></script>
+  <script src="https://unpkg.com/compromise@latest/builds/compromise.min.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>
+

--- a/main.js
+++ b/main.js
@@ -1,0 +1,30 @@
+// Credits: Abdulazeem Shaikh
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true
+    }
+  });
+
+  win.loadFile(path.join(__dirname, 'index.html'));
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "live-logistics-map",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "live-logistics-map",
+      "version": "1.0.0",
+      "license": "ISC",
+      "author": "Abdulazeem Shaikh"
+    }
+  },
+  "author": "Abdulazeem Shaikh"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "live-logistics-map",
+  "version": "1.0.0",
+  "description": "Leaflet map that allows drawing routes and tagging them.",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "build": "electron-builder -w",
+    "test": "echo 'No tests specified' && exit 0"
+  },
+  "keywords": [
+    "leaflet",
+    "logistics",
+    "map"
+  ],
+  "author": "Abdulazeem Shaikh",
+  "license": "ISC",
+  "devDependencies": {
+    "electron": "^28.2.2",
+    "electron-builder": "^24.6.3"
+  },
+  "build": {
+    "appId": "com.logistics.map",
+    "productName": "Live Logistics Map"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,301 @@
+// Credits: Abdulazeem Shaikh
+const map = L.map('map').setView([0, 0], 2);
+
+const lightLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap contributors'
+});
+const darkLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+  attribution: '&copy; OpenStreetMap contributors & CartoDB'
+});
+const satelliteLayer = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+  attribution: 'Tiles &copy; Esri'
+});
+let heatLayer = null;
+
+lightLayer.addTo(map);
+
+const featureGroup = new L.FeatureGroup();
+map.addLayer(featureGroup);
+
+const drawControl = new L.Control.Draw({
+  draw: {
+    polygon: false,
+    circle: false,
+    circlemarker: false,
+    rectangle: false,
+    marker: false,
+    polyline: {
+      shapeOptions: {
+        color: '#f357a1',
+        weight: 4
+      }
+    }
+  },
+  edit: {
+    featureGroup: featureGroup
+  }
+});
+
+map.addControl(drawControl);
+
+const routes = [];
+
+// Prompt for tags when a line is created
+map.on(L.Draw.Event.CREATED, function (event) {
+  const layer = event.layer;
+  if (event.layerType === 'polyline') {
+    const tagString = prompt('Enter tags for this route (comma separated):', '');
+    const tags = tagString ? tagString.split(',').map(t => t.trim()).filter(t => t.length) : [];
+    layer.bindPopup(tags.length ? 'Tags: ' + tags.join(', ') : 'No tags');
+    layer.tags = tags; // store tags on layer for later reference
+  }
+  featureGroup.addLayer(layer);
+  routes.push(layer);
+  applyFilters();
+});
+
+// Example: click a line to show its tags in alert
+featureGroup.on('click', e => {
+  if (e.layer && e.layer.tags) {
+    alert('Tags: ' + e.layer.tags.join(', '));
+  }
+});
+
+// Up to 15 reliable logistics-related RSS feeds
+const RSS_SOURCES = [
+  { name: 'The Loadstar', url: 'https://theloadstar.com/feed/' },
+  { name: 'Port Technology', url: 'https://www.porttechnology.org/news/feed/' },
+  { name: 'Supply Chain Digital', url: 'https://www.supplychaindigital.com/rss' },
+  { name: 'Maritime Executive', url: 'https://www.maritime-executive.com/rss' },
+  { name: 'FreightWaves', url: 'https://www.freightwaves.com/feed' },
+  { name: 'Container News', url: 'https://container-news.com/feed/' },
+  { name: 'Seatrade Maritime', url: 'https://www.seatrade-maritime.com/rss.xml' },
+  { name: 'Hellenic Shipping News', url: 'https://www.hellenicshippingnews.com/feed/' },
+  { name: 'gCaptain', url: 'https://gcaptain.com/feed/' },
+  { name: 'Splash 247', url: 'https://splash247.com/feed/' },
+  { name: 'Journal of Commerce', url: 'https://www.joc.com/rssfeed' },
+  { name: 'Inbound Logistics', url: 'https://www.inboundlogistics.com/rss' },
+  { name: 'DC Velocity', url: 'https://www.dcvelocity.com/rss' },
+  { name: 'Logistics Management', url: 'https://www.logisticsmgmt.com/rss' },
+  { name: 'Transport Topics', url: 'https://www.ttnews.com/rssfeed/ttnews.xml' }
+];
+const MAX_SOURCES = 15; // safeguard against overloading
+
+const KEYWORDS = ['logistic', 'supply chain', 'port', 'terminal'];
+
+// Extract possible place names from text using the compromise NLP library
+function extractLocations(text) {
+  try {
+    return nlp(text).places().out('array');
+  } catch {
+    return [];
+  }
+}
+
+// Geocode a list of place names and return the most probable match
+async function geocodeBest(places) {
+  let best = null;
+  for (const place of places) {
+    const url = `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(place)}`;
+    try {
+      const res = await fetch(url);
+      const data = await res.json();
+      if (data && data.length) {
+        const { lat, lon, address, importance } = data[0];
+        if (!best || (importance || 0) > (best.importance || 0)) {
+          best = {
+            lat: parseFloat(lat),
+            lon: parseFloat(lon),
+            country: address && address.country ? address.country : 'Unknown',
+            importance: importance || 0
+          };
+        }
+      }
+    } catch (e) {
+      console.error('Geocoding failed', e);
+    }
+  }
+  return best;
+}
+
+const newsMarkers = [];
+const countrySelect = document.getElementById('country-filter');
+const timeSelect = document.getElementById('time-filter');
+const applyBtn = document.getElementById('apply-filters');
+const themeSelect = document.getElementById('theme-select');
+const logoVideo = document.getElementById('logo-video');
+const tagInput = document.getElementById('route-tag-filter');
+
+if (logoVideo) {
+  logoVideo.addEventListener('mouseenter', () => logoVideo.play());
+  logoVideo.addEventListener('mouseleave', () => {
+    logoVideo.pause();
+    logoVideo.currentTime = 0;
+  });
+}
+
+function populateCountryOptions() {
+  if (!countrySelect) return;
+  const countries = [...new Set(newsMarkers.map(n => n.country))];
+  countrySelect.innerHTML = '<option value="all">All Countries</option>';
+  countries.forEach(c => {
+    const option = document.createElement('option');
+    option.value = c;
+    option.textContent = c;
+    countrySelect.appendChild(option);
+  });
+}
+
+function showFilteredMarkers() {
+  newsMarkers.forEach(n => {
+    if (n.visible) {
+      if (!map.hasLayer(n.marker)) n.marker.addTo(map);
+    } else if (map.hasLayer(n.marker)) {
+      map.removeLayer(n.marker);
+    }
+  });
+}
+
+function applyFilters() {
+  if (!countrySelect || !timeSelect) return;
+  const country = countrySelect.value;
+  const time = timeSelect.value;
+  const now = Date.now();
+  const ranges = {
+    day: 24 * 60 * 60 * 1000,
+    month: 30 * 24 * 60 * 60 * 1000,
+    year: 365 * 24 * 60 * 60 * 1000
+  };
+  const cutoff = now - (ranges[time] || ranges.month);
+  newsMarkers.forEach(n => {
+    const matchesCountry = country === 'all' || n.country === country;
+    const matchesDate = n.date.getTime() >= cutoff;
+    n.visible = matchesCountry && matchesDate;
+  });
+
+  const tag = tagInput ? tagInput.value.trim().toLowerCase() : '';
+  routes.forEach(r => {
+    const matchesTag = !tag || (r.tags && r.tags.some(t => t.toLowerCase().includes(tag)));
+    if (matchesTag) {
+      if (!featureGroup.hasLayer(r)) featureGroup.addLayer(r);
+    } else if (featureGroup.hasLayer(r)) {
+      featureGroup.removeLayer(r);
+    }
+  });
+  if (themeSelect && themeSelect.value === 'heatmap') {
+    applyTheme();
+  } else {
+    showFilteredMarkers();
+  }
+}
+
+if (applyBtn) {
+  applyBtn.addEventListener('click', applyFilters);
+}
+
+function applyTheme() {
+  if (!themeSelect) return;
+  const theme = themeSelect.value;
+  [lightLayer, darkLayer, satelliteLayer].forEach(l => map.removeLayer(l));
+  if (heatLayer) {
+    map.removeLayer(heatLayer);
+    heatLayer = null;
+  }
+  switch (theme) {
+    case 'dark':
+      darkLayer.addTo(map);
+      showFilteredMarkers();
+      break;
+    case 'satellite':
+      satelliteLayer.addTo(map);
+      showFilteredMarkers();
+      break;
+    case 'heatmap':
+      lightLayer.addTo(map);
+      newsMarkers.forEach(n => { if (map.hasLayer(n.marker)) map.removeLayer(n.marker); });
+      heatLayer = L.heatLayer(
+        newsMarkers.filter(n => n.visible).map(n => {
+          const { lat, lng } = n.marker.getLatLng();
+          return [lat, lng];
+        }),
+        { radius: 25 }
+      );
+      heatLayer.addTo(map);
+      break;
+    default:
+      lightLayer.addTo(map);
+      showFilteredMarkers();
+      break;
+  }
+}
+
+if (themeSelect) {
+  themeSelect.addEventListener('change', applyTheme);
+}
+
+async function fetchNews() {
+  const list = document.getElementById('news-list');
+  if (!list) return;
+  list.innerHTML = '<li>Loading...</li>';
+  try {
+    const results = await Promise.all(
+      RSS_SOURCES.slice(0, MAX_SOURCES).map(src =>
+        fetch(`https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(src.url)}`)
+          .then(r => r.json())
+          .then(data => data.items
+            .filter(item => {
+              const text = `${item.title} ${(item.description || '')}`.toLowerCase();
+              return KEYWORDS.some(k => text.includes(k));
+            })
+            .slice(0, 5)
+            .map(item => ({
+              source: src.name,
+              title: item.title,
+              link: item.link,
+              pubDate: item.pubDate,
+              description: item.description
+            })))
+          .catch(() => [])
+      )
+    );
+    list.innerHTML = '';
+    // remove old markers
+    newsMarkers.forEach(n => map.removeLayer(n.marker));
+    newsMarkers.length = 0;
+    if (heatLayer) {
+      map.removeLayer(heatLayer);
+      heatLayer = null;
+    }
+
+    for (const item of results.flat()) {
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>${item.source}:</strong> <a href="${item.link}" target="_blank">${item.title}</a>`;
+      list.appendChild(li);
+
+      const places = extractLocations(`${item.title} ${item.description || ''}`);
+      const geo = places.length ? await geocodeBest(places) : null;
+      let marker = null;
+      if (geo) {
+        marker = L.marker([geo.lat, geo.lon]).bindPopup(
+          `<strong>${item.source}</strong><br><a href="${item.link}" target="_blank">${item.title}</a>`
+        );
+        marker.addTo(map);
+        newsMarkers.push({ marker, country: geo.country, date: new Date(item.pubDate) });
+      }
+
+      li.addEventListener('click', e => {
+        if (marker && e.target.tagName.toLowerCase() !== 'a') {
+          map.setView(marker.getLatLng(), 6);
+          marker.openPopup();
+        }
+      });
+    }
+    populateCountryOptions();
+    applyFilters();
+  } catch (err) {
+    list.innerHTML = '<li>Failed to load news.</li>';
+  }
+}
+
+fetchNews();
+setInterval(fetchNews, 6 * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary
- Restore visible credit for Abdulazeem Shaikh across HTML, JS, and package metadata
- Maintain interactive logistics map that prompts for tags when routes are drawn
- Allow filtering drawn routes by tag alongside country, time, and theme filters

## Testing
- `npm test`
- `npm run build` *(fails: electron-builder: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a009d533648324ba7438dfaffec8dc